### PR TITLE
Update deprecated dash modules

### DIFF
--- a/scrubdash/dash_server/apps/about_page.py
+++ b/scrubdash/dash_server/apps/about_page.py
@@ -3,7 +3,7 @@
 import logging
 
 import dash_bootstrap_components as dbc
-import dash_html_components as html
+from dash import html
 
 from scrubdash.dash_server.apps.navbar import default_navbar
 

--- a/scrubdash/dash_server/apps/graphs_page.py
+++ b/scrubdash/dash_server/apps/graphs_page.py
@@ -4,10 +4,9 @@ import logging
 from datetime import datetime, timedelta
 
 import dash_bootstrap_components as dbc
-import dash_core_components as dcc
-import dash_html_components as html
 import pandas as pd
 import plotly.express as px
+from dash import dcc, html
 from dash.dependencies import Input, Output, State
 
 from scrubdash.dash_server.app import app

--- a/scrubdash/dash_server/apps/history_page.py
+++ b/scrubdash/dash_server/apps/history_page.py
@@ -11,11 +11,10 @@ from io import BytesIO
 
 import dash
 import dash_bootstrap_components as dbc
-import dash_core_components as dcc
 import dash_daq as daq
-import dash_html_components as html
 import numpy as np
 import pandas as pd
+from dash import dcc, html
 from dash.dependencies import ALL, ALLSMALLER, MATCH, Input, Output, State
 from PIL import Image, ImageDraw, ImageFont
 

--- a/scrubdash/dash_server/apps/labels_page.py
+++ b/scrubdash/dash_server/apps/labels_page.py
@@ -8,8 +8,8 @@ from io import BytesIO
 
 import dash
 import dash_bootstrap_components as dbc
-import dash_html_components as html
 import numpy as np
+from dash import html
 from dash.dependencies import Input, Output
 from PIL import Image
 

--- a/scrubdash/dash_server/apps/main_page.py
+++ b/scrubdash/dash_server/apps/main_page.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 
 import dash_bootstrap_components as dbc
-import dash_html_components as html
+from dash import html
 from dash.dependencies import Input, Output
 
 from scrubdash.dash_server.app import app

--- a/scrubdash/dash_server/apps/navbar.py
+++ b/scrubdash/dash_server/apps/navbar.py
@@ -2,7 +2,7 @@
 
 import dash
 import dash_bootstrap_components as dbc
-import dash_html_components as html
+from dash import html
 from dash.dependencies import Input, Output
 
 from scrubdash.dash_server.app import app

--- a/scrubdash/dash_server/dash_server.py
+++ b/scrubdash/dash_server/dash_server.py
@@ -6,8 +6,7 @@ asyncio server and handles which pages to show based on the url.
 import logging
 import re
 
-import dash_core_components as dcc
-import dash_html_components as html
+from dash import dcc, html
 from dash.dependencies import Input, Output
 
 from scrubdash.dash_server.app import app

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,6 @@ setuptools.setup(
         'dash',
         'dash_daq',
         'dash_bootstrap_components ',
-        'dash_core_components ',
-        'dash_html_components',
         'numpy',
         'pandas',
         'Pillow',


### PR DESCRIPTION
- Update dash modules for all of the layout pages
- Update dash modules for dash_server
- Remove deprecated dash modules from setup.py as they are no longer needed